### PR TITLE
Revised: css, js, etc coldn't loaded.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf 
       - ./nginx/conf.d/:/etc/nginx/conf.d/
       - ./nginx/log:/var/log/nginx
+      - ./html:/var/www/html
     ports:
       - 80:80
     depends_on:


### PR DESCRIPTION
WordPressのトップ画面(install.php)のトップ画面の表示が崩れていた(*)ため、その修正。  
(*) 以下のcss等がロードできていなかった
    wp-includes/css/buttons.min.css    
    wp-admin/css/forms.min.css  
    ...  

docker-compose.ymlにてnginxのマウント部分に/var/www/htmlを追加することで、
WordPress側の/var/www/htmlをロードできるようにした。


 